### PR TITLE
Add Debian package configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 license = "GPL-2.0-only"
 authors = ["Samuel Rüegger"]
+description = "A simple GTK4/Libadwaita application to manage autostart entries"
+homepage = "https://github.com/srueegger/bootmate"
+repository = "https://github.com/srueegger/bootmate"
 
 [dependencies]
 gtk = { version = "0.10", package = "gtk4", features = ["v4_20"] }
@@ -11,3 +14,20 @@ libadwaita = { version = "0.8", features = ["v1_8"] }
 gettext-rs = { version = "0.7", features = ["gettext-system"] }
 glib = "0.21"
 gio = "0.21"
+
+[package.metadata.deb]
+maintainer = "Samuel Rüegger"
+copyright = "2025, Samuel Rüegger <mail@example.com>"
+extended-description = """\
+Boot Mate is a modern GTK4/Libadwaita application for managing autostart entries on Linux.
+It allows you to easily add, edit, and remove applications that start automatically when you log in.
+Features include separate views for user and system autostart entries."""
+depends = "$auto, libgtk-4-1, libadwaita-1-0"
+section = "utils"
+priority = "optional"
+assets = [
+    ["target/release/bootmate", "usr/bin/", "755"],
+    ["data/ch.srueegger.bootmate.desktop", "usr/share/applications/", "644"],
+    ["data/icons/ch.srueegger.bootmate.svg", "usr/share/icons/hicolor/scalable/apps/", "644"],
+    ["README.md", "usr/share/doc/bootmate/", "644"],
+]

--- a/data/ch.srueegger.bootmate.desktop
+++ b/data/ch.srueegger.bootmate.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Boot Mate
+GenericName=Autostart Manager
+Comment=Manage autostart entries
+Exec=bootmate
+Icon=ch.srueegger.bootmate
+Terminal=false
+Categories=System;Settings;
+Keywords=autostart;startup;session;
+StartupNotify=true


### PR DESCRIPTION
- Add cargo-deb metadata to Cargo.toml
- Create .desktop file for application menu entry
- Configure package dependencies and assets
- Enable building of .deb packages with 'cargo deb'

Package location: target/debian/bootmate_0.1.0-1_amd64.deb

🤖 Generated with [Claude Code](https://claude.com/claude-code)