### PR TITLE
Fix: Prevent overwriting existing autostart entries

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -17,10 +17,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: data/ch.srueegger.bootmate.desktop.in:3
+#: data/ch.srueegger.bootmate.metainfo.xml.in:7
+#: data/ui/window.ui:6
+#: src/application.rs
 msgid "Boot Mate"
 msgstr "Boot Mate"
 
 #: data/ch.srueegger.bootmate.desktop.in:4
+#: data/ch.srueegger.bootmate.metainfo.xml.in:8
+#: src/application.rs
 msgid "Manage autostart entries"
 msgstr "Autostart-Einträge verwalten"
 
@@ -28,27 +33,17 @@ msgstr "Autostart-Einträge verwalten"
 msgid "autostart;startup;boot;session;"
 msgstr "autostart;automatisch;start;sitzung;"
 
-#: data/ch.srueegger.bootmate.metainfo.xml.in:7
-msgid "Boot Mate"
-msgstr "Boot Mate"
-
-#: data/ch.srueegger.bootmate.metainfo.xml.in:8
-msgid "Manage autostart entries"
-msgstr "Autostart-Einträge verwalten"
-
-#: data/ui/window.ui:6
-msgid "Boot Mate"
-msgstr "Boot Mate"
-
 #: data/ui/window.ui:14
 msgid "Main Menu"
 msgstr "Hauptmenü"
 
 #: data/ui/window.ui:27
+#: src/window.rs
 msgid "No Autostart Entries"
 msgstr "Keine Autostart-Einträge"
 
 #: data/ui/window.ui:28
+#: src/window.rs
 msgid "No applications are configured to start automatically"
 msgstr "Keine Anwendungen sind für den automatischen Start konfiguriert"
 
@@ -73,6 +68,7 @@ msgid "Edit Autostart Entry"
 msgstr "Autostart-Eintrag bearbeiten"
 
 #: src/entry_row.rs
+#: src/window.rs
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -81,6 +77,7 @@ msgid "Save"
 msgstr "Speichern"
 
 #: src/entry_row.rs
+#: src/window.rs
 msgid "Command"
 msgstr "Befehl"
 
@@ -92,18 +89,46 @@ msgstr "Autostart-Eintrag löschen?"
 msgid "This action cannot be undone."
 msgstr "Diese Aktion kann nicht rückgängig gemacht werden."
 
-#: src/application.rs
-msgid "Boot Mate"
-msgstr "Boot Mate"
-
-#: src/application.rs
-msgid "Manage autostart entries"
-msgstr "Autostart-Einträge verwalten"
+#: src/window.rs
+msgid "Add Autostart Entry"
+msgstr "Autostart-Eintrag hinzufügen"
 
 #: src/window.rs
-msgid "No Autostart Entries"
-msgstr "Keine Autostart-Einträge"
+msgid "Add"
+msgstr "Hinzufügen"
 
 #: src/window.rs
-msgid "No applications are configured to start automatically"
-msgstr "Keine Anwendungen sind für den automatischen Start konfiguriert"
+msgid "Name"
+msgstr "Name"
+
+#: src/window.rs
+msgid "Entry Type"
+msgstr "Eintragstyp"
+
+#: src/window.rs
+msgid "Select from installed applications"
+msgstr "Aus installierten Anwendungen auswählen"
+
+#: src/window.rs
+msgid "Enter custom command"
+msgstr "Benutzerdefinierten Befehl eingeben"
+
+#: src/window.rs
+msgid "Application"
+msgstr "Anwendung"
+
+#: src/window.rs
+msgid "Browse..."
+msgstr "Durchsuchen..."
+
+#: src/window.rs
+msgid "Entry Already Exists"
+msgstr "Eintrag existiert bereits"
+
+#: src/window.rs
+msgid "An autostart entry with this name already exists. Please choose a different name."
+msgstr "Ein Autostart-Eintrag mit diesem Namen existiert bereits. Bitte wählen Sie einen anderen Namen."
+
+#: src/window.rs
+msgid "OK"
+msgstr "OK"

--- a/po/en.po
+++ b/po/en.po
@@ -17,10 +17,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: data/ch.srueegger.bootmate.desktop.in:3
+#: data/ch.srueegger.bootmate.metainfo.xml.in:7
+#: data/ui/window.ui:6
+#: src/application.rs
 msgid "Boot Mate"
 msgstr "Boot Mate"
 
 #: data/ch.srueegger.bootmate.desktop.in:4
+#: data/ch.srueegger.bootmate.metainfo.xml.in:8
+#: src/application.rs
 msgid "Manage autostart entries"
 msgstr "Manage autostart entries"
 
@@ -28,19 +33,17 @@ msgstr "Manage autostart entries"
 msgid "autostart;startup;boot;session;"
 msgstr "autostart;startup;boot;session;"
 
-#: data/ui/window.ui:6
-msgid "Boot Mate"
-msgstr "Boot Mate"
-
 #: data/ui/window.ui:14
 msgid "Main Menu"
 msgstr "Main Menu"
 
 #: data/ui/window.ui:27
+#: src/window.rs
 msgid "No Autostart Entries"
 msgstr "No Autostart Entries"
 
 #: data/ui/window.ui:28
+#: src/window.rs
 msgid "No applications are configured to start automatically"
 msgstr "No applications are configured to start automatically"
 
@@ -65,6 +68,7 @@ msgid "Edit Autostart Entry"
 msgstr "Edit Autostart Entry"
 
 #: src/entry_row.rs
+#: src/window.rs
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -73,6 +77,7 @@ msgid "Save"
 msgstr "Save"
 
 #: src/entry_row.rs
+#: src/window.rs
 msgid "Command"
 msgstr "Command"
 
@@ -84,18 +89,46 @@ msgstr "Delete Autostart Entry?"
 msgid "This action cannot be undone."
 msgstr "This action cannot be undone."
 
-#: src/application.rs
-msgid "Boot Mate"
-msgstr "Boot Mate"
-
-#: src/application.rs
-msgid "Manage autostart entries"
-msgstr "Manage autostart entries"
+#: src/window.rs
+msgid "Add Autostart Entry"
+msgstr "Add Autostart Entry"
 
 #: src/window.rs
-msgid "No Autostart Entries"
-msgstr "No Autostart Entries"
+msgid "Add"
+msgstr "Add"
 
 #: src/window.rs
-msgid "No applications are configured to start automatically"
-msgstr "No applications are configured to start automatically"
+msgid "Name"
+msgstr "Name"
+
+#: src/window.rs
+msgid "Entry Type"
+msgstr "Entry Type"
+
+#: src/window.rs
+msgid "Select from installed applications"
+msgstr "Select from installed applications"
+
+#: src/window.rs
+msgid "Enter custom command"
+msgstr "Enter custom command"
+
+#: src/window.rs
+msgid "Application"
+msgstr "Application"
+
+#: src/window.rs
+msgid "Browse..."
+msgstr "Browse..."
+
+#: src/window.rs
+msgid "Entry Already Exists"
+msgstr "Entry Already Exists"
+
+#: src/window.rs
+msgid "An autostart entry with this name already exists. Please choose a different name."
+msgstr "An autostart entry with this name already exists. Please choose a different name."
+
+#: src/window.rs
+msgid "OK"
+msgstr "OK"

--- a/src/window.rs
+++ b/src/window.rs
@@ -319,6 +319,19 @@ impl BootMateWindow {
                     let user_dir = glib::user_config_dir();
                     let file_path = user_dir.join("autostart").join(&filename);
 
+                    // Check if file already exists
+                    if file_path.exists() {
+                        let error_dialog = adw::AlertDialog::builder()
+                            .heading(gettext("Entry Already Exists"))
+                            .body(gettext("An autostart entry with this name already exists. Please choose a different name."))
+                            .build();
+                        error_dialog.add_response("ok", &gettext("OK"));
+                        error_dialog.set_default_response(Some("ok"));
+                        error_dialog.set_close_response("ok");
+                        error_dialog.present(Some(&window));
+                        return;
+                    }
+
                     // Create new autostart entry
                     let entry = AutostartEntry {
                         name: name.to_string(),


### PR DESCRIPTION
Add validation to check if an autostart entry already exists before creating a new one. When a user tries to create an entry with a name that would generate an existing filename, show an error dialog instead of silently overwriting the existing entry.

Changes:
- Added file existence check in show_add_entry_dialog()
- Display error dialog when duplicate entry name is detected
- Added translations for error messages (EN/DE)
- Fixed duplicate msgid entries in PO files by consolidating source references

The filename is generated from the entry name by converting to lowercase, replacing spaces with hyphens, and filtering to alphanumeric characters. This fix ensures that entries with names that normalize to the same filename (e.g., "My App" and "my app") cannot overwrite each other.