### PR TITLE
Improve locale initialization and add new translations (EN/DE)

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -132,3 +132,19 @@ msgstr "Ein Autostart-Eintrag mit diesem Namen existiert bereits. Bitte wählen 
 #: src/window.rs
 msgid "OK"
 msgstr "OK"
+
+#: data/ui/window.ui:77
+msgid "User Autostart"
+msgstr "Benutzer-Autostart"
+
+#: data/ui/window.ui:86
+msgid "Applications that start automatically for your user account"
+msgstr "Anwendungen, die automatisch für Ihr Benutzerkonto starten"
+
+#: data/ui/window.ui:115
+msgid "System Autostart"
+msgstr "System-Autostart"
+
+#: data/ui/window.ui:124
+msgid "System-wide applications that start automatically"
+msgstr "Systemweite Anwendungen, die automatisch starten"

--- a/po/en.po
+++ b/po/en.po
@@ -132,3 +132,19 @@ msgstr "An autostart entry with this name already exists. Please choose a differ
 #: src/window.rs
 msgid "OK"
 msgstr "OK"
+
+#: data/ui/window.ui:77
+msgid "User Autostart"
+msgstr "User Autostart"
+
+#: data/ui/window.ui:86
+msgid "Applications that start automatically for your user account"
+msgstr "Applications that start automatically for your user account"
+
+#: data/ui/window.ui:115
+msgid "System Autostart"
+msgstr "System Autostart"
+
+#: data/ui/window.ui:124
+msgid "System-wide applications that start automatically"
+msgstr "System-wide applications that start automatically"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,13 +9,50 @@ mod window;
 use application::BootMateApplication;
 use config::{APP_ID, GETTEXT_PACKAGE, LOCALEDIR};
 
-use gettextrs::{bind_textdomain_codeset, bindtextdomain, textdomain};
+use gettextrs::{bind_textdomain_codeset, bindtextdomain, setlocale, textdomain, LocaleCategory};
 use gtk::prelude::*;
 use gtk::{gio, glib};
 
 fn main() -> glib::ExitCode {
+    // Initialize locale from environment
+    setlocale(LocaleCategory::LcAll, "");
+
     // Initialize gettext
-    bindtextdomain(GETTEXT_PACKAGE, LOCALEDIR).expect("Failed to bind text domain");
+    // For dev builds, try to use locale files from build directory
+    // Check if our translation file actually exists in the system locale dir
+    let system_locale_file = std::path::PathBuf::from(LOCALEDIR)
+        .join("de/LC_MESSAGES")
+        .join(format!("{}.mo", GETTEXT_PACKAGE));
+
+    let locale_dir = if system_locale_file.exists() {
+        LOCALEDIR.to_string()
+    } else {
+        // Dev build: try multiple paths to find locale files
+        let exe_path = std::env::current_exe().unwrap_or_default();
+
+        // Try build/po relative to executable (meson build)
+        let meson_po = exe_path
+            .parent()
+            .and_then(|p| p.parent())
+            .map(|p| p.join("po"));
+
+        // Try build/po relative to project root (cargo build)
+        let cargo_po = std::env::current_dir()
+            .ok()
+            .map(|p| p.join("build/po"));
+
+        // Use the first path that exists
+        let build_po = meson_po
+            .as_ref()
+            .filter(|p| p.exists())
+            .or(cargo_po.as_ref().filter(|p| p.exists()))
+            .cloned()
+            .unwrap_or_else(|| std::path::PathBuf::from("build/po"));
+
+        build_po.to_string_lossy().to_string()
+    };
+
+    bindtextdomain(GETTEXT_PACKAGE, &locale_dir).expect("Failed to bind text domain");
     bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8")
         .expect("Failed to set text domain encoding");
     textdomain(GETTEXT_PACKAGE).expect("Failed to set text domain");


### PR DESCRIPTION
This pull request enhances localization support and translations for the application. The main changes include improved locale initialization logic for development builds and the addition of new translation strings for the autostart feature in both German and English.

Localization improvements:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL12-R55): Added logic to initialize the locale from the environment using `setlocale`, and improved how translation files are located for development builds by checking multiple possible paths before falling back to a default. This ensures translations work correctly in both system and development environments.

Translation updates:

* [`po/de.po`](diffhunk://#diff-6686c8173bf4fa70e9c9755259206f2c5c4fa9fde6269d36e5262dcc09abcf25R135-R150): Added German translations for new UI strings related to user and system autostart features.
* [`po/en.po`](diffhunk://#diff-35fef39c3d37be70c8b43498d5afbb42946e0b8e7b58d91c77aa4f9459512ba8R135-R150): Added English translations for new UI strings related to user and system autostart features.- Use `setlocale` to initialize locale settings from the environment
- Implement fallback mechanism for locating translation files in dev builds
- Added new translations for "User Autostart" and "System Autostart" (EN/DE)