### PR TITLE
Release version 1.1.0: Improved Snap compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bootmate"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 license = "GPL-2.0-only"
 authors = ["Samuel Rüegger"]
@@ -9,8 +9,8 @@ homepage = "https://github.com/srueegger/bootmate"
 repository = "https://github.com/srueegger/bootmate"
 
 [dependencies]
-gtk = { version = "0.10", package = "gtk4", features = ["v4_20"] }
-libadwaita = { version = "0.8", features = ["v1_8"] }
+gtk = { version = "0.10", package = "gtk4", features = ["v4_12"] }
+libadwaita = { version = "0.8", features = ["v1_5"] }
 gettext-rs = { version = "0.7", features = ["gettext-system"] }
 glib = "0.21"
 gio = "0.21"

--- a/data/ch.srueegger.bootmate.metainfo.xml.in
+++ b/data/ch.srueegger.bootmate.metainfo.xml.in
@@ -25,6 +25,17 @@
   <developer_name>Samuel Rüegger</developer_name>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="1.1.0" date="2025-11-30">
+      <description>
+        <p>Improved Snap compatibility</p>
+        <ul>
+          <li>Lower GTK requirement to 4.12 for broader compatibility</li>
+          <li>Requires libadwaita 1.5 (available in Ubuntu 24.04)</li>
+          <li>Snap package now works on Ubuntu 24.04 (core24)</li>
+          <li>Fixed GitHub Actions automated builds</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.0.0" date="2025-11-30">
       <description>
         <p>First stable release</p>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'bootmate',
   'rust',
-  version: '1.0.0',
+  version: '1.1.0',
   license: 'GPL-2.0-only',
   meson_version: '>= 0.59.0',
 )
@@ -14,7 +14,7 @@ base_id = 'ch.srueegger.bootmate'
 dependency('glib-2.0', version: '>= 2.66')
 dependency('gio-2.0', version: '>= 2.66')
 dependency('gtk4', version: '>= 4.10')
-dependency('libadwaita-1', version: '>= 1.4')
+dependency('libadwaita-1', version: '>= 1.5')
 
 cargo = find_program('cargo', required: true)
 glib_compile_resources = find_program('glib-compile-resources', required: true)

--- a/po/de.po
+++ b/po/de.po
@@ -5,7 +5,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: bootmate 1.0.0\n"
+"Project-Id-Version: bootmate 1.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-01-28 12:00+0100\n"
 "PO-Revision-Date: 2025-01-28 12:00+0100\n"

--- a/po/en.po
+++ b/po/en.po
@@ -5,7 +5,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: bootmate 1.0.0\n"
+"Project-Id-Version: bootmate 1.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-01-28 12:00+0100\n"
 "PO-Revision-Date: 2025-01-28 12:00+0100\n"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: bootmate
 base: core24
-version: '1.0.0'
+version: '1.1.0'
 summary: Manage autostart entries
 description: |
   Boot Mate provides a simple and intuitive interface to manage your


### PR DESCRIPTION
- Lower GTK requirement from 4.20 to 4.12 for Ubuntu 24.04 support
- Update libadwaita requirement to 1.5 (available in Ubuntu 24.04)
- Update version to 1.1.0 across all package files
- Add release notes to metainfo.xml

This enables the Snap package to build and run on Ubuntu 24.04 (core24) while maintaining all application functionality.
