### PR TITLE
Workflow config for arm64 and snap-arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,47 +136,33 @@ jobs:
 
   build-snap-arm64:
     name: Build Snap (ARM64)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm64
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build Snap for ARM64
+      - name: Install build dependencies
         run: |
-          docker run --rm --platform linux/arm64 \
-            --privileged \
-            -v ${{ github.workspace }}:/workspace \
-            -w /workspace \
-            ubuntu:24.04 bash -c "
-              apt-get update && \
-              apt-get install -y \
-                curl \
-                gcc \
-                meson \
-                ninja-build \
-                pkg-config \
-                libgtk-4-dev \
-                libadwaita-1-dev \
-                libglib2.0-dev \
-                libglib2.0-bin \
-                gettext \
-                desktop-file-utils \
-                snapd \
-                squashfs-tools && \
-              systemctl start snapd && \
-              sleep 5 && \
-              snap install snapcraft --classic && \
-              snapcraft pack --destructive-mode
-            "
+          sudo apt-get update
+          sudo apt-get install -y \
+            curl \
+            gcc \
+            meson \
+            ninja-build \
+            pkg-config \
+            libgtk-4-dev \
+            libadwaita-1-dev \
+            libglib2.0-dev \
+            libglib2.0-bin \
+            gettext \
+            desktop-file-utils
+
+      - name: Install snapcraft
+        run: sudo snap install snapcraft --classic
+
+      - name: Build snap with destructive mode
+        run: snapcraft pack --destructive-mode
 
       - name: Upload Snap
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR adds ARM64 architecture support to the release workflow, enabling multi-architecture builds for both DEB and Snap packages.

### Changes
- Added `build-deb-arm64` job to build DEB packages for ARM64 architecture
- Added `build-snap-arm64` job to build Snap packages for ARM64 architecture
- ARM64 DEB builds use QEMU emulation in Docker containers
- ARM64 Snap builds run on native ARM64 runners (`ubuntu-24.04-arm64`)

### Build Artifacts
The workflow now produces four artifacts per release:
- `deb-amd64` - DEB package for AMD64
- `deb-arm64` - DEB package for ARM64
- `snap-amd64` - Snap package for AMD64
- `snap-arm64` - Snap package for ARM64

### Requirements
- ARM64 Snap builds require access to GitHub's ARM64 runners 
- All builds can still be triggered via releases or manual workflow dispatch