### PR TITLE
Bump version to 1.2.0 and add centralized version management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bootmate"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 license = "GPL-2.0-only"
 authors = ["Samuel Rüegger"]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -174,4 +174,4 @@ Boot Mate folgt Semantic Versioning:
 ---
 
 **Letzte Aktualisierung:** 2025-11-30
-**Aktuelle Version:** 1.0.0
+**Aktuelle Version:** 1.2.0

--- a/data/ch.srueegger.bootmate.metainfo.xml.in
+++ b/data/ch.srueegger.bootmate.metainfo.xml.in
@@ -25,6 +25,18 @@
   <developer_name>Samuel Rüegger</developer_name>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="1.2.0" date="2025-12-13">
+      <description>
+        <p>New features and improvements</p>
+        <ul>
+          <li>Add enable/disable toggle switches for quick control of autostart entries</li>
+          <li>Visual feedback: disabled entries appear dimmed for better clarity</li>
+          <li>Larger application icons for improved visibility</li>
+          <li>Fix markup parsing warnings for entry names with special characters</li>
+          <li>Professional README without emojis</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.1.0" date="2025-11-30">
       <description>
         <p>Improved compatibility and build system</p>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'bootmate',
   'rust',
-  version: '1.1.0',
+  version: '1.2.0',
   license: 'GPL-2.0-only',
   meson_version: '>= 0.59.0',
 )

--- a/po/de.po
+++ b/po/de.po
@@ -5,7 +5,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: bootmate 1.1.0\n"
+"Project-Id-Version: bootmate 1.2.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-01-28 12:00+0100\n"
 "PO-Revision-Date: 2025-01-28 12:00+0100\n"

--- a/po/en.po
+++ b/po/en.po
@@ -5,7 +5,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: bootmate 1.1.0\n"
+"Project-Id-Version: bootmate 1.2.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-01-28 12:00+0100\n"
 "PO-Revision-Date: 2025-01-28 12:00+0100\n"

--- a/update-version.sh
+++ b/update-version.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Script to update version across all project files
+
+set -e
+
+if [ -z "$1" ]; then
+    echo "Usage: ./update-version.sh <new-version>"
+    echo "Example: ./update-version.sh 1.2.0"
+    exit 1
+fi
+
+NEW_VERSION="$1"
+
+# Validate version format (X.Y.Z)
+if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: Version must be in format X.Y.Z (e.g., 1.2.0)"
+    exit 1
+fi
+
+echo "Updating version to $NEW_VERSION..."
+
+# Update meson.build
+echo "  - meson.build"
+sed -i "s/version: '[0-9]\+\.[0-9]\+\.[0-9]\+'/version: '$NEW_VERSION'/" meson.build
+
+# Update Cargo.toml
+echo "  - Cargo.toml"
+sed -i "s/^version = \"[0-9]\+\.[0-9]\+\.[0-9]\+\"/version = \"$NEW_VERSION\"/" Cargo.toml
+
+# Update po files
+echo "  - po/en.po"
+sed -i "s/Project-Id-Version: bootmate [0-9]\+\.[0-9]\+\.[0-9]\+/Project-Id-Version: bootmate $NEW_VERSION/" po/en.po
+
+echo "  - po/de.po"
+sed -i "s/Project-Id-Version: bootmate [0-9]\+\.[0-9]\+\.[0-9]\+/Project-Id-Version: bootmate $NEW_VERSION/" po/de.po
+
+# Update metainfo.xml.in - only update the first (newest) release version
+echo "  - data/ch.srueegger.bootmate.metainfo.xml.in"
+# Get current date in YYYY-MM-DD format
+CURRENT_DATE=$(date +%Y-%m-%d)
+# Update only the first occurrence of release version
+sed -i "0,/<release version=\"[0-9]\+\.[0-9]\+\.[0-9]\+\"/s/<release version=\"[0-9]\+\.[0-9]\+\.[0-9]\+\" date=\"[^\"]*\">/<release version=\"$NEW_VERSION\" date=\"$CURRENT_DATE\">/" data/ch.srueegger.bootmate.metainfo.xml.in
+
+# Update RELEASE.md
+echo "  - RELEASE.md"
+sed -i "s/\*\*Aktuelle Version:\*\* [0-9]\+\.[0-9]\+\.[0-9]\+/**Aktuelle Version:** $NEW_VERSION/" RELEASE.md
+
+echo ""
+echo "Version updated to $NEW_VERSION successfully!"
+echo ""
+echo "Modified files:"
+echo "  - meson.build"
+echo "  - Cargo.toml"
+echo "  - po/en.po"
+echo "  - po/de.po"
+echo "  - data/ch.srueegger.bootmate.metainfo.xml.in (version and date)"
+echo "  - RELEASE.md"
+echo ""
+echo "Next steps:"
+echo "  1. Review changes: git diff"
+echo "  2. Add release notes to data/ch.srueegger.bootmate.metainfo.xml.in"
+echo "  3. Commit: git add . && git commit -m 'Bump version to $NEW_VERSION'"


### PR DESCRIPTION
- Add update-version.sh script for centralized version updates
- Update version to 1.2.0 across all files:
  - meson.build
  - Cargo.toml
  - po/en.po and po/de.po
  - data/ch.srueegger.bootmate.metainfo.xml.in
  - RELEASE.md
- Add release notes for version 1.2.0 with new features:
  - Enable/disable toggle switches
  - Visual feedback for disabled entries
  - Larger application icons
  - Fixed markup parsing warnings
  - Professional README
