### PR TITLE
Prepare 50.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@
 
 ## Build System
 - Meson + Cargo (Rust)
-- Dependencies: GTK4 >= 4.10, libadwaita >= 1.5, glib >= 2.66
+- Dependencies: GTK4 >= 4.22.1, libadwaita >= 1.9.0, glib >= 2.66
 - Build: `meson setup build --prefix=/usr -Dprofile=release && meson compile -C build`
 
 ## Distribution

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "bootmate"
-version = "1.3.1"
+version = "50.0.0"
 dependencies = [
  "gettext-rs",
  "gio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-rs"
-version = "0.21.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01fe135c0bd16afe262b6dea349bd5ea30e6de50708cec639aae7c5c14cc7e4"
+checksum = "5cc8d9aa793480744cd9a0524fef1a2e197d9eaa0f739cde19d16aba530dcb95"
 dependencies = [
  "bitflags",
  "cairo-sys-rs",
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-sys-rs"
-version = "0.21.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c28280c6b12055b5e39e4554271ae4e6630b27c0da9148c4cf6485fc6d245c"
+checksum = "f8b4985713047f5faee02b8db6a6ef32bbb50269ff53c1aee716d1d195b76d54"
 dependencies = [
  "glib-sys",
  "libc",
@@ -65,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.20.6"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cef5b5a1a6827c7322ae2a636368a573006b27cfa76c7ebd53e834daeaab6a"
+checksum = "3c6b04e07d8080154ed4ac03546d9a2b303cc2fe1901ba0b35b301516e289368"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "gdk-pixbuf"
-version = "0.21.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "debb0d39e3cdd84626edfd54d6e4a6ba2da9a0ef2e796e691c4e9f8646fda00c"
+checksum = "25f420376dbee041b2db374ce4573892a36222bb3f6c0c43e24f0d67eae9b646"
 dependencies = [
  "gdk-pixbuf-sys",
  "gio",
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "gdk-pixbuf-sys"
-version = "0.21.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd95ad50b9a3d2551e25dd4f6892aff0b772fe5372d84514e9d0583af60a0ce7"
+checksum = "48f31b37b1fc4b48b54f6b91b7ef04c18e00b4585d98359dd7b998774bbd91fb"
 dependencies = [
  "gio-sys",
  "glib-sys",
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756564212bbe4a4ce05d88ffbd2582581ac6003832d0d32822d0825cca84bfbf"
+checksum = "fa528049fd8726974a7aa1a6e1421f891e7579bea6cc6d54056ab4d1a1b937e7"
 dependencies = [
  "cairo-rs",
  "gdk-pixbuf",
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4-sys"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e5b3ccf591826a4adcc83f5f57b4e59d1925cb4bf620b0d645f79498b034"
+checksum = "3dd48b1b03dce78ab52805ac35cfb69c48af71a03af5723231d8583718738377"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "gio"
-version = "0.21.5"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ff48bf600c68b476e61dc6b7c762f2f4eb91deef66583ba8bb815c30b5811a"
+checksum = "816b6743c46b217aa8fba679095ac6f2162fd53259dc8f186fcdbff9c555db03"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -263,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "gio-sys"
-version = "0.21.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0071fe88dba8e40086c8ff9bbb62622999f49628344b1d1bf490a48a29d80f22"
+checksum = "64729ba2772c080448f9f966dba8f4456beeb100d8c28a865ef8a0f2ef4987e1"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.21.5"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16de123c2e6c90ce3b573b7330de19be649080ec612033d397d72da265f1bd8b"
+checksum = "039f93465ac17e6cb02d16f16572cd3e43a77e736d5ecc461e71b9c9c5c0569c"
 dependencies = [
  "bitflags",
  "futures-channel",
@@ -297,12 +297,11 @@ dependencies = [
 
 [[package]]
 name = "glib-macros"
-version = "0.21.5"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf59b675301228a696fe01c3073974643365080a76cc3ed5bc2cbc466ad87f17"
+checksum = "bda575994e3689b1bc12f89c3df621ead46ff292623b76b4710a3a5b79be54bb"
 dependencies = [
  "heck",
- "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -310,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "glib-sys"
-version = "0.21.5"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d95e1a3a19ae464a7286e14af9a90683c64d70c02532d88d87ce95056af3e6c"
+checksum = "1eb23a616a3dbc7fc15bbd26f58756ff0b04c8a894df3f0680cd21011db6a642"
 dependencies = [
  "libc",
  "system-deps",
@@ -320,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "gobject-sys"
-version = "0.21.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dca35da0d19a18f4575f3cb99fe1c9e029a2941af5662f326f738a21edaf294"
+checksum = "18eda93f09d3778f38255b231b17ef67195013a592c91624a4daf8bead875565"
 dependencies = [
  "glib-sys",
  "libc",
@@ -331,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "graphene-rs"
-version = "0.21.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2730030ac9db663fd8bfe1e7093742c1cafb92db9c315c9417c29032341fe2f9"
+checksum = "c7d1b7881f96869f49808b6adfe906a93a57a34204952253444d68c3208d71f1"
 dependencies = [
  "glib",
  "graphene-sys",
@@ -342,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "graphene-sys"
-version = "0.21.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915e32091ea9ad241e4b044af62b7351c2d68aeb24f489a0d7f37a0fc484fd93"
+checksum = "517f062f3fd6b7fd3e57a3f038a74b3c23ca32f51199ff028aa704609943f79c"
 dependencies = [
  "glib-sys",
  "libc",
@@ -354,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "gsk4"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e755de9d8c5896c5beaa028b89e1969d067f1b9bf1511384ede971f5983aa153"
+checksum = "53c912dfcbd28acace5fc99c40bb9f25e1dcb73efb1f2608327f66a99acdcb62"
 dependencies = [
  "cairo-rs",
  "gdk4",
@@ -369,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "gsk4-sys"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ce91472391146f482065f1041876d8f869057b195b95399414caa163d72f4f7"
+checksum = "d7d54bbc7a9d8b6ffe4f0c95eede15ccfb365c8bf521275abe6bcfb57b18fb8a"
 dependencies = [
  "cairo-sys-rs",
  "gdk4-sys",
@@ -385,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acb21d53cfc6f7bfaf43549731c43b67ca47d87348d81c8cfc4dcdd44828e1a4"
+checksum = "87f671029e3f5288fd35e03a6e6b19e1ce643b10a3d261d33d183e453f6c52fe"
 dependencies = [
  "cairo-rs",
  "field-offset",
@@ -406,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4-macros"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ccfb5a14a3d941244815d5f8101fa12d4577b59cc47245778d8d907b0003e42"
+checksum = "3581b242ba62fdff122ebb626ea641582ec326031622bd19d60f85029c804a87"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -418,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4-sys"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842577fe5a1ee15d166cd3afe804ce0cab6173bc789ca32e21308834f20088dd"
+checksum = "d0786e7e8e0550d0ab2df4d0d90032f22033e07d5ed78b6a1b2e51b05340339e"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -465,9 +464,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libadwaita"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb09e12bf8f73342b3315c839d0a7668cc0ccebd78490c49fec48bab15d5484b"
+checksum = "bc0da4e27b20d3e71f830e5b0f0188d22c257986bf421c02cfde777fe07932a4"
 dependencies = [
  "gdk4",
  "gio",
@@ -480,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "libadwaita-sys"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7f94227ba87eb596fecada2491f04e357d507324142f77bf76d9e6be4a3e31"
+checksum = "aaee067051c5d3c058d050d167688b80b67de1950cfca77730549aa761fc5d7d"
 dependencies = [
  "gdk4-sys",
  "gio-sys",
@@ -496,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "locale_config"
@@ -568,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "pango"
-version = "0.21.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1d85e2078077a065bb7fc072783d5bcd4e51b379f22d67107d0a16937eb69"
+checksum = "25d8f224eddef627b896d2f7b05725b3faedbd140e0e8343446f0d34f34238ee"
 dependencies = [
  "gio",
  "glib",
@@ -580,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "pango-sys"
-version = "0.21.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f06627d36ed5ff303d2df65211fc2e52ba5b17bf18dd80ff3d9628d6e06cfd"
+checksum = "bbd111a20ca90fedf03e09c59783c679c00900f1d8491cca5399f5e33609d5d6"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -592,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
@@ -604,9 +603,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
@@ -622,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -654,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc_version"
@@ -765,10 +764,10 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -781,31 +780,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+name = "toml_datetime"
+version = "1.0.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.0.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
 
 [[package]]
 name = "unicode-ident"
@@ -858,9 +866,15 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bootmate"
 version = "50.0.0"
-edition = "2021"
+edition = "2024"
 license = "GPL-2.0-only"
 authors = ["Samuel Rüegger"]
 description = "A simple GTK4/Libadwaita application to manage autostart entries"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bootmate"
-version = "1.3.1"
+version = "50.0.0"
 edition = "2021"
 license = "GPL-2.0-only"
 authors = ["Samuel Rüegger"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ gio = "0.22"
 
 [package.metadata.deb]
 maintainer = "Samuel Rüegger"
-copyright = "2025, Samuel Rüegger <mail@example.com>"
+copyright = "2025, Samuel Rüegger <samuel@rueegger.me>"
 extended-description = """\
 Boot Mate is a modern GTK4/Libadwaita application for managing autostart entries on Linux.
 It allows you to easily add, edit, and remove applications that start automatically when you log in.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ homepage = "https://github.com/srueegger/bootmate"
 repository = "https://github.com/srueegger/bootmate"
 
 [dependencies]
-gtk = { version = "0.10", package = "gtk4", features = ["v4_12"] }
-libadwaita = { version = "0.8", features = ["v1_5"] }
+gtk = { version = "0.11", package = "gtk4", features = ["v4_22"] }
+libadwaita = { version = "0.9", features = ["v1_9"] }
 gettext-rs = { version = "0.7", features = ["gettext-system"] }
-glib = "0.21"
-gio = "0.21"
+glib = "0.22"
+gio = "0.22"
 
 [package.metadata.deb]
 maintainer = "Samuel Rüegger"

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ If you prefer to build from source, see the [Building](#building) section below.
 
 ### Runtime Dependencies
 
-- GTK 4.10 or later
-- libadwaita 1.5 or later
+- GTK 4.22.1 or later
+- libadwaita 1.9.0 or later
 - GLib 2.66 or later
 
 ### Build Dependencies

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,166 +2,96 @@
 
 Diese Anleitung beschreibt den kompletten Prozess zum Veröffentlichen einer neuen Version von Boot Mate.
 
-## Übersicht
-
-Bei jedem Release werden automatisch über GitHub Actions DEB-Pakete gebaut:
-- **DEB-Paket** (`bootmate_X.Y.Z_amd64.deb`)
-- **DEB-Paket ARM64** (`bootmate_X.Y.Z_arm64.deb`)
-
-Diese werden als Release Assets auf GitHub bereitgestellt.
-
 ---
 
 ## 📋 Release-Prozess (Schritt für Schritt)
 
 ### 1. Versionsnummer aktualisieren
 
-Die Version muss in folgenden Dateien angepasst werden:
-
-- `Cargo.toml` (Zeile 3)
-- `meson.build` (Zeile 4)
-- `po/en.po` (Zeile 8)
-- `po/de.po` (Zeile 8)
-- `data/me.rueegger.bootmate.metainfo.xml.in` (Zeile 28 - Version UND Datum)
-
-**Beispiel für Version 1.1.0:**
-
 ```bash
-# In allen Dateien 1.0.0 → 1.1.0 ersetzen
-# Datum in metainfo.xml.in aktualisieren
+./update-version.sh 50.1
 ```
 
-### 2. Release-Notizen in metainfo.xml.in
+Das Script aktualisiert automatisch:
+- `meson.build`
+- `Cargo.toml` (als X.Y.0 für SemVer)
+- `po/en.po` und `po/de.po`
+- `data/me.rueegger.bootmate.metainfo.xml.in` (Version + Datum)
+
+### 2. Changelog in metainfo.xml.in schreiben
 
 Aktualisiere die Release-Beschreibung in `data/me.rueegger.bootmate.metainfo.xml.in`:
 
 ```xml
-<release version="1.1.0" date="2025-12-15">
+<release version="50.1" date="2026-XX-XX">
   <description>
-    <p>Neue Features und Verbesserungen</p>
+    <p>Kurze Beschreibung</p>
     <ul>
       <li>Feature 1</li>
-      <li>Feature 2</li>
-      <li>Bugfix 3</li>
+      <li>Bugfix 2</li>
     </ul>
   </description>
 </release>
 ```
 
-### 3. Änderungen committen
+### 3. cargo-sources.json aktualisieren
+
+Falls sich Rust-Abhängigkeiten geändert haben:
+
+```bash
+cargo update
+python3 ~/Projects/me.rueegger.cargo/flatpak-cargo-generator.py Cargo.lock -o cargo-sources.json
+```
+
+### 4. Lokal testen (Flatpak)
+
+```bash
+flatpak-builder --user --install --force-clean --disable-rofiles-fuse _flatpak me.rueegger.bootmate.yml
+flatpak run me.rueegger.bootmate
+```
+
+### 5. Änderungen committen und pushen
 
 ```bash
 git add .
-git commit -m "Bump version to X.Y.Z"
+git commit -m "Bump version to 50.1"
+git push
 ```
 
-### 4. Release-Branch erstellen (optional)
-
-Für größere Releases empfiehlt sich ein Release-Branch:
+### 6. Tag erstellen und pushen
 
 ```bash
-git checkout -b release-X.Y.Z
-git push -u origin release-X.Y.Z
+git tag -a v50.1 -m "Release version 50.1"
+git push origin v50.1
 ```
 
-Dann Pull Request erstellen und nach Review in `main` mergen.
-
-### 5. Tag erstellen und pushen
+### 7. Flatpak veröffentlichen
 
 ```bash
-# Auf main branch wechseln
-git checkout main
-git pull
-
-# Tag erstellen
-git tag -a vX.Y.Z -m "Release version X.Y.Z"
-
-# Tag pushen
-git push origin vX.Y.Z
+~/Projects/flatpak.rueegger.dev/publish.sh bootmate
 ```
 
-### 6. GitHub Release erstellen
+### 8. GitHub Release erstellen
 
 1. Gehe zu: https://github.com/srueegger/bootmate/releases
 2. Klicke auf **"Draft a new release"**
-3. Wähle den Tag: `vX.Y.Z`
-4. Release Title: `Boot Mate X.Y.Z`
+3. Wähle den Tag: `v50.1`
+4. Release Title: `Boot Mate 50.1`
 5. Beschreibung mit Features/Fixes
 6. Klicke auf **"Publish release"**
-
-### 7. GitHub Actions läuft automatisch
-
-Nach dem Veröffentlichen des Releases:
-
-1. GitHub Actions startet automatisch (`.github/workflows/release.yml`)
-2. Baut DEB-Pakete für AMD64 und ARM64 mit `cargo deb`
-3. Lädt die Pakete als Release Assets hoch
-
-**Status überprüfen:**
-- Gehe zu **Actions** Tab auf GitHub
-- Sieh dir den "Build and Release" Workflow an
-
-**Nach erfolgreichem Build:**
-- Die Pakete erscheinen automatisch unter dem Release
-
----
-
-## 🔧 Troubleshooting
-
-### GitHub Actions Build schlägt fehl
-
-**DEB Build Fehler:**
-- Überprüfe `Cargo.toml` `[package.metadata.deb]` Sektion
-- Stelle sicher, dass `build-release` Verzeichnis korrekt ist
-- Überprüfe, ob alle Build-Dependencies installiert sind
-
----
-
-## 📊 Status überprüfen
-
-### GitHub Release Assets
-
-Gehe zu: https://github.com/srueegger/bootmate/releases/tag/vX.Y.Z
-
-Erwartete Assets:
-- ✅ `bootmate_X.Y.Z_amd64.deb`
-- ✅ `bootmate_X.Y.Z_arm64.deb`
 
 ---
 
 ## 🎯 Checkliste für Release
 
-- [ ] Version in allen Dateien aktualisiert
-- [ ] Release-Notizen in metainfo.xml.in geschrieben
-- [ ] Änderungen committed
+- [ ] Versionsnummer aktualisiert (`./update-version.sh X.Y`)
+- [ ] Changelog in `metainfo.xml.in` geschrieben
+- [ ] `cargo-sources.json` aktualisiert (falls Abhängigkeiten geändert)
+- [ ] Lokaler Flatpak-Build erfolgreich
+- [ ] Änderungen committed und gepusht
 - [ ] Tag erstellt und gepusht
-- [ ] GitHub Release veröffentlicht
-- [ ] GitHub Actions erfolgreich durchgelaufen
-- [ ] Release Assets vorhanden (DEB für AMD64 und ARM64)
-
----
-
-## 📝 Wichtige Notizen
-
-### Automatische Builds
-
-- **DEB**: Wird mit `cargo deb` gebaut (nutzt Cargo.toml Konfiguration)
-- **Architekturen**: AMD64 und ARM64
-- **Trigger**: Automatisch bei Release-Veröffentlichung ODER manuell via "Actions" Tab
-
-### Sandbox Permissions
-
-Die App zeigt ein Banner an, wenn Flatpak-Berechtigungen nicht gesetzt sind:
-
-- **Flatpak**: Zeigt `flatpak override` Befehle
-
-### Versionierung
-
-Boot Mate folgt Semantic Versioning:
-- **MAJOR.MINOR.PATCH** (z.B. 1.2.3)
-- MAJOR: Breaking Changes
-- MINOR: Neue Features (backwards compatible)
-- PATCH: Bugfixes
+- [ ] Flatpak veröffentlicht (`publish.sh bootmate`)
+- [ ] GitHub Release erstellt
 
 ---
 
@@ -169,9 +99,18 @@ Boot Mate folgt Semantic Versioning:
 
 - **GitHub Repository:** https://github.com/srueegger/bootmate
 - **GitHub Releases:** https://github.com/srueegger/bootmate/releases
-- **GitHub Actions:** https://github.com/srueegger/bootmate/actions
+- **Flatpak Repository:** https://flatpak.rueegger.dev
 
 ---
 
-**Letzte Aktualisierung:** 2026-02-21
-**Aktuelle Version:** 1.3.1
+### Versionierung
+
+Boot Mate folgt dem GNOME-Versionsschema:
+- **MAJOR.MINOR** (z.B. 50.0, 50.1)
+- MAJOR: GNOME-Version (50 = GNOME 50)
+- MINOR: Releases innerhalb des GNOME-Zyklus
+
+---
+
+**Letzte Aktualisierung:** 2026-03-21
+**Aktuelle Version:** 50.0

--- a/cargo-sources.json
+++ b/cargo-sources.json
@@ -54,53 +54,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cairo-rs/cairo-rs-0.21.5.crate",
-        "sha256": "b01fe135c0bd16afe262b6dea349bd5ea30e6de50708cec639aae7c5c14cc7e4",
-        "dest": "cargo/vendor/cairo-rs-0.21.5"
+        "url": "https://static.crates.io/crates/cairo-rs/cairo-rs-0.22.0.crate",
+        "sha256": "5cc8d9aa793480744cd9a0524fef1a2e197d9eaa0f739cde19d16aba530dcb95",
+        "dest": "cargo/vendor/cairo-rs-0.22.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b01fe135c0bd16afe262b6dea349bd5ea30e6de50708cec639aae7c5c14cc7e4\", \"files\": {}}",
-        "dest": "cargo/vendor/cairo-rs-0.21.5",
+        "contents": "{\"package\": \"5cc8d9aa793480744cd9a0524fef1a2e197d9eaa0f739cde19d16aba530dcb95\", \"files\": {}}",
+        "dest": "cargo/vendor/cairo-rs-0.22.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cairo-sys-rs/cairo-sys-rs-0.21.5.crate",
-        "sha256": "06c28280c6b12055b5e39e4554271ae4e6630b27c0da9148c4cf6485fc6d245c",
-        "dest": "cargo/vendor/cairo-sys-rs-0.21.5"
+        "url": "https://static.crates.io/crates/cairo-sys-rs/cairo-sys-rs-0.22.0.crate",
+        "sha256": "f8b4985713047f5faee02b8db6a6ef32bbb50269ff53c1aee716d1d195b76d54",
+        "dest": "cargo/vendor/cairo-sys-rs-0.22.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"06c28280c6b12055b5e39e4554271ae4e6630b27c0da9148c4cf6485fc6d245c\", \"files\": {}}",
-        "dest": "cargo/vendor/cairo-sys-rs-0.21.5",
+        "contents": "{\"package\": \"f8b4985713047f5faee02b8db6a6ef32bbb50269ff53c1aee716d1d195b76d54\", \"files\": {}}",
+        "dest": "cargo/vendor/cairo-sys-rs-0.22.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cc/cc-1.2.56.crate",
-        "sha256": "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2",
-        "dest": "cargo/vendor/cc-1.2.56"
+        "url": "https://static.crates.io/crates/cc/cc-1.2.57.crate",
+        "sha256": "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423",
+        "dest": "cargo/vendor/cc-1.2.57"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2\", \"files\": {}}",
-        "dest": "cargo/vendor/cc-1.2.56",
+        "contents": "{\"package\": \"7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423\", \"files\": {}}",
+        "dest": "cargo/vendor/cc-1.2.57",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cfg-expr/cfg-expr-0.20.6.crate",
-        "sha256": "78cef5b5a1a6827c7322ae2a636368a573006b27cfa76c7ebd53e834daeaab6a",
-        "dest": "cargo/vendor/cfg-expr-0.20.6"
+        "url": "https://static.crates.io/crates/cfg-expr/cfg-expr-0.20.7.crate",
+        "sha256": "3c6b04e07d8080154ed4ac03546d9a2b303cc2fe1901ba0b35b301516e289368",
+        "dest": "cargo/vendor/cfg-expr-0.20.7"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"78cef5b5a1a6827c7322ae2a636368a573006b27cfa76c7ebd53e834daeaab6a\", \"files\": {}}",
-        "dest": "cargo/vendor/cfg-expr-0.20.6",
+        "contents": "{\"package\": \"3c6b04e07d8080154ed4ac03546d9a2b303cc2fe1901ba0b35b301516e289368\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg-expr-0.20.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -236,53 +236,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gdk-pixbuf/gdk-pixbuf-0.21.5.crate",
-        "sha256": "debb0d39e3cdd84626edfd54d6e4a6ba2da9a0ef2e796e691c4e9f8646fda00c",
-        "dest": "cargo/vendor/gdk-pixbuf-0.21.5"
+        "url": "https://static.crates.io/crates/gdk-pixbuf/gdk-pixbuf-0.22.0.crate",
+        "sha256": "25f420376dbee041b2db374ce4573892a36222bb3f6c0c43e24f0d67eae9b646",
+        "dest": "cargo/vendor/gdk-pixbuf-0.22.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"debb0d39e3cdd84626edfd54d6e4a6ba2da9a0ef2e796e691c4e9f8646fda00c\", \"files\": {}}",
-        "dest": "cargo/vendor/gdk-pixbuf-0.21.5",
+        "contents": "{\"package\": \"25f420376dbee041b2db374ce4573892a36222bb3f6c0c43e24f0d67eae9b646\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk-pixbuf-0.22.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gdk-pixbuf-sys/gdk-pixbuf-sys-0.21.5.crate",
-        "sha256": "bd95ad50b9a3d2551e25dd4f6892aff0b772fe5372d84514e9d0583af60a0ce7",
-        "dest": "cargo/vendor/gdk-pixbuf-sys-0.21.5"
+        "url": "https://static.crates.io/crates/gdk-pixbuf-sys/gdk-pixbuf-sys-0.22.0.crate",
+        "sha256": "48f31b37b1fc4b48b54f6b91b7ef04c18e00b4585d98359dd7b998774bbd91fb",
+        "dest": "cargo/vendor/gdk-pixbuf-sys-0.22.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"bd95ad50b9a3d2551e25dd4f6892aff0b772fe5372d84514e9d0583af60a0ce7\", \"files\": {}}",
-        "dest": "cargo/vendor/gdk-pixbuf-sys-0.21.5",
+        "contents": "{\"package\": \"48f31b37b1fc4b48b54f6b91b7ef04c18e00b4585d98359dd7b998774bbd91fb\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk-pixbuf-sys-0.22.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gdk4/gdk4-0.10.3.crate",
-        "sha256": "756564212bbe4a4ce05d88ffbd2582581ac6003832d0d32822d0825cca84bfbf",
-        "dest": "cargo/vendor/gdk4-0.10.3"
+        "url": "https://static.crates.io/crates/gdk4/gdk4-0.11.1.crate",
+        "sha256": "fa528049fd8726974a7aa1a6e1421f891e7579bea6cc6d54056ab4d1a1b937e7",
+        "dest": "cargo/vendor/gdk4-0.11.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"756564212bbe4a4ce05d88ffbd2582581ac6003832d0d32822d0825cca84bfbf\", \"files\": {}}",
-        "dest": "cargo/vendor/gdk4-0.10.3",
+        "contents": "{\"package\": \"fa528049fd8726974a7aa1a6e1421f891e7579bea6cc6d54056ab4d1a1b937e7\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk4-0.11.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gdk4-sys/gdk4-sys-0.10.3.crate",
-        "sha256": "a6d4e5b3ccf591826a4adcc83f5f57b4e59d1925cb4bf620b0d645f79498b034",
-        "dest": "cargo/vendor/gdk4-sys-0.10.3"
+        "url": "https://static.crates.io/crates/gdk4-sys/gdk4-sys-0.11.1.crate",
+        "sha256": "3dd48b1b03dce78ab52805ac35cfb69c48af71a03af5723231d8583718738377",
+        "dest": "cargo/vendor/gdk4-sys-0.11.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a6d4e5b3ccf591826a4adcc83f5f57b4e59d1925cb4bf620b0d645f79498b034\", \"files\": {}}",
-        "dest": "cargo/vendor/gdk4-sys-0.10.3",
+        "contents": "{\"package\": \"3dd48b1b03dce78ab52805ac35cfb69c48af71a03af5723231d8583718738377\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk4-sys-0.11.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -314,170 +314,170 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gio/gio-0.21.5.crate",
-        "sha256": "c5ff48bf600c68b476e61dc6b7c762f2f4eb91deef66583ba8bb815c30b5811a",
-        "dest": "cargo/vendor/gio-0.21.5"
+        "url": "https://static.crates.io/crates/gio/gio-0.22.2.crate",
+        "sha256": "816b6743c46b217aa8fba679095ac6f2162fd53259dc8f186fcdbff9c555db03",
+        "dest": "cargo/vendor/gio-0.22.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c5ff48bf600c68b476e61dc6b7c762f2f4eb91deef66583ba8bb815c30b5811a\", \"files\": {}}",
-        "dest": "cargo/vendor/gio-0.21.5",
+        "contents": "{\"package\": \"816b6743c46b217aa8fba679095ac6f2162fd53259dc8f186fcdbff9c555db03\", \"files\": {}}",
+        "dest": "cargo/vendor/gio-0.22.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gio-sys/gio-sys-0.21.5.crate",
-        "sha256": "0071fe88dba8e40086c8ff9bbb62622999f49628344b1d1bf490a48a29d80f22",
-        "dest": "cargo/vendor/gio-sys-0.21.5"
+        "url": "https://static.crates.io/crates/gio-sys/gio-sys-0.22.0.crate",
+        "sha256": "64729ba2772c080448f9f966dba8f4456beeb100d8c28a865ef8a0f2ef4987e1",
+        "dest": "cargo/vendor/gio-sys-0.22.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0071fe88dba8e40086c8ff9bbb62622999f49628344b1d1bf490a48a29d80f22\", \"files\": {}}",
-        "dest": "cargo/vendor/gio-sys-0.21.5",
+        "contents": "{\"package\": \"64729ba2772c080448f9f966dba8f4456beeb100d8c28a865ef8a0f2ef4987e1\", \"files\": {}}",
+        "dest": "cargo/vendor/gio-sys-0.22.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/glib/glib-0.21.5.crate",
-        "sha256": "16de123c2e6c90ce3b573b7330de19be649080ec612033d397d72da265f1bd8b",
-        "dest": "cargo/vendor/glib-0.21.5"
+        "url": "https://static.crates.io/crates/glib/glib-0.22.3.crate",
+        "sha256": "039f93465ac17e6cb02d16f16572cd3e43a77e736d5ecc461e71b9c9c5c0569c",
+        "dest": "cargo/vendor/glib-0.22.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"16de123c2e6c90ce3b573b7330de19be649080ec612033d397d72da265f1bd8b\", \"files\": {}}",
-        "dest": "cargo/vendor/glib-0.21.5",
+        "contents": "{\"package\": \"039f93465ac17e6cb02d16f16572cd3e43a77e736d5ecc461e71b9c9c5c0569c\", \"files\": {}}",
+        "dest": "cargo/vendor/glib-0.22.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/glib-macros/glib-macros-0.21.5.crate",
-        "sha256": "cf59b675301228a696fe01c3073974643365080a76cc3ed5bc2cbc466ad87f17",
-        "dest": "cargo/vendor/glib-macros-0.21.5"
+        "url": "https://static.crates.io/crates/glib-macros/glib-macros-0.22.2.crate",
+        "sha256": "bda575994e3689b1bc12f89c3df621ead46ff292623b76b4710a3a5b79be54bb",
+        "dest": "cargo/vendor/glib-macros-0.22.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"cf59b675301228a696fe01c3073974643365080a76cc3ed5bc2cbc466ad87f17\", \"files\": {}}",
-        "dest": "cargo/vendor/glib-macros-0.21.5",
+        "contents": "{\"package\": \"bda575994e3689b1bc12f89c3df621ead46ff292623b76b4710a3a5b79be54bb\", \"files\": {}}",
+        "dest": "cargo/vendor/glib-macros-0.22.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/glib-sys/glib-sys-0.21.5.crate",
-        "sha256": "2d95e1a3a19ae464a7286e14af9a90683c64d70c02532d88d87ce95056af3e6c",
-        "dest": "cargo/vendor/glib-sys-0.21.5"
+        "url": "https://static.crates.io/crates/glib-sys/glib-sys-0.22.3.crate",
+        "sha256": "1eb23a616a3dbc7fc15bbd26f58756ff0b04c8a894df3f0680cd21011db6a642",
+        "dest": "cargo/vendor/glib-sys-0.22.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2d95e1a3a19ae464a7286e14af9a90683c64d70c02532d88d87ce95056af3e6c\", \"files\": {}}",
-        "dest": "cargo/vendor/glib-sys-0.21.5",
+        "contents": "{\"package\": \"1eb23a616a3dbc7fc15bbd26f58756ff0b04c8a894df3f0680cd21011db6a642\", \"files\": {}}",
+        "dest": "cargo/vendor/glib-sys-0.22.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gobject-sys/gobject-sys-0.21.5.crate",
-        "sha256": "2dca35da0d19a18f4575f3cb99fe1c9e029a2941af5662f326f738a21edaf294",
-        "dest": "cargo/vendor/gobject-sys-0.21.5"
+        "url": "https://static.crates.io/crates/gobject-sys/gobject-sys-0.22.0.crate",
+        "sha256": "18eda93f09d3778f38255b231b17ef67195013a592c91624a4daf8bead875565",
+        "dest": "cargo/vendor/gobject-sys-0.22.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2dca35da0d19a18f4575f3cb99fe1c9e029a2941af5662f326f738a21edaf294\", \"files\": {}}",
-        "dest": "cargo/vendor/gobject-sys-0.21.5",
+        "contents": "{\"package\": \"18eda93f09d3778f38255b231b17ef67195013a592c91624a4daf8bead875565\", \"files\": {}}",
+        "dest": "cargo/vendor/gobject-sys-0.22.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/graphene-rs/graphene-rs-0.21.5.crate",
-        "sha256": "2730030ac9db663fd8bfe1e7093742c1cafb92db9c315c9417c29032341fe2f9",
-        "dest": "cargo/vendor/graphene-rs-0.21.5"
+        "url": "https://static.crates.io/crates/graphene-rs/graphene-rs-0.22.0.crate",
+        "sha256": "c7d1b7881f96869f49808b6adfe906a93a57a34204952253444d68c3208d71f1",
+        "dest": "cargo/vendor/graphene-rs-0.22.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2730030ac9db663fd8bfe1e7093742c1cafb92db9c315c9417c29032341fe2f9\", \"files\": {}}",
-        "dest": "cargo/vendor/graphene-rs-0.21.5",
+        "contents": "{\"package\": \"c7d1b7881f96869f49808b6adfe906a93a57a34204952253444d68c3208d71f1\", \"files\": {}}",
+        "dest": "cargo/vendor/graphene-rs-0.22.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/graphene-sys/graphene-sys-0.21.5.crate",
-        "sha256": "915e32091ea9ad241e4b044af62b7351c2d68aeb24f489a0d7f37a0fc484fd93",
-        "dest": "cargo/vendor/graphene-sys-0.21.5"
+        "url": "https://static.crates.io/crates/graphene-sys/graphene-sys-0.22.0.crate",
+        "sha256": "517f062f3fd6b7fd3e57a3f038a74b3c23ca32f51199ff028aa704609943f79c",
+        "dest": "cargo/vendor/graphene-sys-0.22.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"915e32091ea9ad241e4b044af62b7351c2d68aeb24f489a0d7f37a0fc484fd93\", \"files\": {}}",
-        "dest": "cargo/vendor/graphene-sys-0.21.5",
+        "contents": "{\"package\": \"517f062f3fd6b7fd3e57a3f038a74b3c23ca32f51199ff028aa704609943f79c\", \"files\": {}}",
+        "dest": "cargo/vendor/graphene-sys-0.22.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gsk4/gsk4-0.10.3.crate",
-        "sha256": "e755de9d8c5896c5beaa028b89e1969d067f1b9bf1511384ede971f5983aa153",
-        "dest": "cargo/vendor/gsk4-0.10.3"
+        "url": "https://static.crates.io/crates/gsk4/gsk4-0.11.1.crate",
+        "sha256": "53c912dfcbd28acace5fc99c40bb9f25e1dcb73efb1f2608327f66a99acdcb62",
+        "dest": "cargo/vendor/gsk4-0.11.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e755de9d8c5896c5beaa028b89e1969d067f1b9bf1511384ede971f5983aa153\", \"files\": {}}",
-        "dest": "cargo/vendor/gsk4-0.10.3",
+        "contents": "{\"package\": \"53c912dfcbd28acace5fc99c40bb9f25e1dcb73efb1f2608327f66a99acdcb62\", \"files\": {}}",
+        "dest": "cargo/vendor/gsk4-0.11.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gsk4-sys/gsk4-sys-0.10.3.crate",
-        "sha256": "7ce91472391146f482065f1041876d8f869057b195b95399414caa163d72f4f7",
-        "dest": "cargo/vendor/gsk4-sys-0.10.3"
+        "url": "https://static.crates.io/crates/gsk4-sys/gsk4-sys-0.11.1.crate",
+        "sha256": "d7d54bbc7a9d8b6ffe4f0c95eede15ccfb365c8bf521275abe6bcfb57b18fb8a",
+        "dest": "cargo/vendor/gsk4-sys-0.11.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7ce91472391146f482065f1041876d8f869057b195b95399414caa163d72f4f7\", \"files\": {}}",
-        "dest": "cargo/vendor/gsk4-sys-0.10.3",
+        "contents": "{\"package\": \"d7d54bbc7a9d8b6ffe4f0c95eede15ccfb365c8bf521275abe6bcfb57b18fb8a\", \"files\": {}}",
+        "dest": "cargo/vendor/gsk4-sys-0.11.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gtk4/gtk4-0.10.3.crate",
-        "sha256": "acb21d53cfc6f7bfaf43549731c43b67ca47d87348d81c8cfc4dcdd44828e1a4",
-        "dest": "cargo/vendor/gtk4-0.10.3"
+        "url": "https://static.crates.io/crates/gtk4/gtk4-0.11.1.crate",
+        "sha256": "87f671029e3f5288fd35e03a6e6b19e1ce643b10a3d261d33d183e453f6c52fe",
+        "dest": "cargo/vendor/gtk4-0.11.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"acb21d53cfc6f7bfaf43549731c43b67ca47d87348d81c8cfc4dcdd44828e1a4\", \"files\": {}}",
-        "dest": "cargo/vendor/gtk4-0.10.3",
+        "contents": "{\"package\": \"87f671029e3f5288fd35e03a6e6b19e1ce643b10a3d261d33d183e453f6c52fe\", \"files\": {}}",
+        "dest": "cargo/vendor/gtk4-0.11.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gtk4-macros/gtk4-macros-0.10.3.crate",
-        "sha256": "3ccfb5a14a3d941244815d5f8101fa12d4577b59cc47245778d8d907b0003e42",
-        "dest": "cargo/vendor/gtk4-macros-0.10.3"
+        "url": "https://static.crates.io/crates/gtk4-macros/gtk4-macros-0.11.0.crate",
+        "sha256": "3581b242ba62fdff122ebb626ea641582ec326031622bd19d60f85029c804a87",
+        "dest": "cargo/vendor/gtk4-macros-0.11.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3ccfb5a14a3d941244815d5f8101fa12d4577b59cc47245778d8d907b0003e42\", \"files\": {}}",
-        "dest": "cargo/vendor/gtk4-macros-0.10.3",
+        "contents": "{\"package\": \"3581b242ba62fdff122ebb626ea641582ec326031622bd19d60f85029c804a87\", \"files\": {}}",
+        "dest": "cargo/vendor/gtk4-macros-0.11.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gtk4-sys/gtk4-sys-0.10.3.crate",
-        "sha256": "842577fe5a1ee15d166cd3afe804ce0cab6173bc789ca32e21308834f20088dd",
-        "dest": "cargo/vendor/gtk4-sys-0.10.3"
+        "url": "https://static.crates.io/crates/gtk4-sys/gtk4-sys-0.11.1.crate",
+        "sha256": "d0786e7e8e0550d0ab2df4d0d90032f22033e07d5ed78b6a1b2e51b05340339e",
+        "dest": "cargo/vendor/gtk4-sys-0.11.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"842577fe5a1ee15d166cd3afe804ce0cab6173bc789ca32e21308834f20088dd\", \"files\": {}}",
-        "dest": "cargo/vendor/gtk4-sys-0.10.3",
+        "contents": "{\"package\": \"d0786e7e8e0550d0ab2df4d0d90032f22033e07d5ed78b6a1b2e51b05340339e\", \"files\": {}}",
+        "dest": "cargo/vendor/gtk4-sys-0.11.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -535,40 +535,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/libadwaita/libadwaita-0.8.1.crate",
-        "sha256": "fb09e12bf8f73342b3315c839d0a7668cc0ccebd78490c49fec48bab15d5484b",
-        "dest": "cargo/vendor/libadwaita-0.8.1"
+        "url": "https://static.crates.io/crates/libadwaita/libadwaita-0.9.1.crate",
+        "sha256": "bc0da4e27b20d3e71f830e5b0f0188d22c257986bf421c02cfde777fe07932a4",
+        "dest": "cargo/vendor/libadwaita-0.9.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"fb09e12bf8f73342b3315c839d0a7668cc0ccebd78490c49fec48bab15d5484b\", \"files\": {}}",
-        "dest": "cargo/vendor/libadwaita-0.8.1",
+        "contents": "{\"package\": \"bc0da4e27b20d3e71f830e5b0f0188d22c257986bf421c02cfde777fe07932a4\", \"files\": {}}",
+        "dest": "cargo/vendor/libadwaita-0.9.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/libadwaita-sys/libadwaita-sys-0.8.1.crate",
-        "sha256": "6d7f94227ba87eb596fecada2491f04e357d507324142f77bf76d9e6be4a3e31",
-        "dest": "cargo/vendor/libadwaita-sys-0.8.1"
+        "url": "https://static.crates.io/crates/libadwaita-sys/libadwaita-sys-0.9.1.crate",
+        "sha256": "aaee067051c5d3c058d050d167688b80b67de1950cfca77730549aa761fc5d7d",
+        "dest": "cargo/vendor/libadwaita-sys-0.9.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6d7f94227ba87eb596fecada2491f04e357d507324142f77bf76d9e6be4a3e31\", \"files\": {}}",
-        "dest": "cargo/vendor/libadwaita-sys-0.8.1",
+        "contents": "{\"package\": \"aaee067051c5d3c058d050d167688b80b67de1950cfca77730549aa761fc5d7d\", \"files\": {}}",
+        "dest": "cargo/vendor/libadwaita-sys-0.9.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/libc/libc-0.2.182.crate",
-        "sha256": "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112",
-        "dest": "cargo/vendor/libc-0.2.182"
+        "url": "https://static.crates.io/crates/libc/libc-0.2.183.crate",
+        "sha256": "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d",
+        "dest": "cargo/vendor/libc-0.2.183"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112\", \"files\": {}}",
-        "dest": "cargo/vendor/libc-0.2.182",
+        "contents": "{\"package\": \"b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d\", \"files\": {}}",
+        "dest": "cargo/vendor/libc-0.2.183",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -665,40 +665,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pango/pango-0.21.5.crate",
-        "sha256": "52d1d85e2078077a065bb7fc072783d5bcd4e51b379f22d67107d0a16937eb69",
-        "dest": "cargo/vendor/pango-0.21.5"
+        "url": "https://static.crates.io/crates/pango/pango-0.22.0.crate",
+        "sha256": "25d8f224eddef627b896d2f7b05725b3faedbd140e0e8343446f0d34f34238ee",
+        "dest": "cargo/vendor/pango-0.22.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"52d1d85e2078077a065bb7fc072783d5bcd4e51b379f22d67107d0a16937eb69\", \"files\": {}}",
-        "dest": "cargo/vendor/pango-0.21.5",
+        "contents": "{\"package\": \"25d8f224eddef627b896d2f7b05725b3faedbd140e0e8343446f0d34f34238ee\", \"files\": {}}",
+        "dest": "cargo/vendor/pango-0.22.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pango-sys/pango-sys-0.21.5.crate",
-        "sha256": "b4f06627d36ed5ff303d2df65211fc2e52ba5b17bf18dd80ff3d9628d6e06cfd",
-        "dest": "cargo/vendor/pango-sys-0.21.5"
+        "url": "https://static.crates.io/crates/pango-sys/pango-sys-0.22.0.crate",
+        "sha256": "bbd111a20ca90fedf03e09c59783c679c00900f1d8491cca5399f5e33609d5d6",
+        "dest": "cargo/vendor/pango-sys-0.22.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b4f06627d36ed5ff303d2df65211fc2e52ba5b17bf18dd80ff3d9628d6e06cfd\", \"files\": {}}",
-        "dest": "cargo/vendor/pango-sys-0.21.5",
+        "contents": "{\"package\": \"bbd111a20ca90fedf03e09c59783c679c00900f1d8491cca5399f5e33609d5d6\", \"files\": {}}",
+        "dest": "cargo/vendor/pango-sys-0.22.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pin-project-lite/pin-project-lite-0.2.16.crate",
-        "sha256": "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b",
-        "dest": "cargo/vendor/pin-project-lite-0.2.16"
+        "url": "https://static.crates.io/crates/pin-project-lite/pin-project-lite-0.2.17.crate",
+        "sha256": "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd",
+        "dest": "cargo/vendor/pin-project-lite-0.2.17"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b\", \"files\": {}}",
-        "dest": "cargo/vendor/pin-project-lite-0.2.16",
+        "contents": "{\"package\": \"a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd\", \"files\": {}}",
+        "dest": "cargo/vendor/pin-project-lite-0.2.17",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -717,14 +717,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-3.4.0.crate",
-        "sha256": "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983",
-        "dest": "cargo/vendor/proc-macro-crate-3.4.0"
+        "url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-3.5.0.crate",
+        "sha256": "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f",
+        "dest": "cargo/vendor/proc-macro-crate-3.5.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983\", \"files\": {}}",
-        "dest": "cargo/vendor/proc-macro-crate-3.4.0",
+        "contents": "{\"package\": \"e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro-crate-3.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -743,14 +743,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/quote/quote-1.0.44.crate",
-        "sha256": "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4",
-        "dest": "cargo/vendor/quote-1.0.44"
+        "url": "https://static.crates.io/crates/quote/quote-1.0.45.crate",
+        "sha256": "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924",
+        "dest": "cargo/vendor/quote-1.0.45"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4\", \"files\": {}}",
-        "dest": "cargo/vendor/quote-1.0.44",
+        "contents": "{\"package\": \"41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924\", \"files\": {}}",
+        "dest": "cargo/vendor/quote-1.0.45",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -782,14 +782,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/regex-syntax/regex-syntax-0.8.9.crate",
-        "sha256": "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c",
-        "dest": "cargo/vendor/regex-syntax-0.8.9"
+        "url": "https://static.crates.io/crates/regex-syntax/regex-syntax-0.8.10.crate",
+        "sha256": "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a",
+        "dest": "cargo/vendor/regex-syntax-0.8.10"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c\", \"files\": {}}",
-        "dest": "cargo/vendor/regex-syntax-0.8.9",
+        "contents": "{\"package\": \"dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a\", \"files\": {}}",
+        "dest": "cargo/vendor/regex-syntax-0.8.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -977,40 +977,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.23.10+spec-1.0.0.crate",
-        "sha256": "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269",
-        "dest": "cargo/vendor/toml_edit-0.23.10+spec-1.0.0"
+        "url": "https://static.crates.io/crates/toml_datetime/toml_datetime-1.0.1+spec-1.1.0.crate",
+        "sha256": "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9",
+        "dest": "cargo/vendor/toml_datetime-1.0.1+spec-1.1.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269\", \"files\": {}}",
-        "dest": "cargo/vendor/toml_edit-0.23.10+spec-1.0.0",
+        "contents": "{\"package\": \"9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_datetime-1.0.1+spec-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml_parser/toml_parser-1.0.9+spec-1.1.0.crate",
-        "sha256": "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4",
-        "dest": "cargo/vendor/toml_parser-1.0.9+spec-1.1.0"
+        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.25.5+spec-1.1.0.crate",
+        "sha256": "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1",
+        "dest": "cargo/vendor/toml_edit-0.25.5+spec-1.1.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4\", \"files\": {}}",
-        "dest": "cargo/vendor/toml_parser-1.0.9+spec-1.1.0",
+        "contents": "{\"package\": \"8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_edit-0.25.5+spec-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml_writer/toml_writer-1.0.6+spec-1.1.0.crate",
-        "sha256": "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607",
-        "dest": "cargo/vendor/toml_writer-1.0.6+spec-1.1.0"
+        "url": "https://static.crates.io/crates/toml_parser/toml_parser-1.0.10+spec-1.1.0.crate",
+        "sha256": "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420",
+        "dest": "cargo/vendor/toml_parser-1.0.10+spec-1.1.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607\", \"files\": {}}",
-        "dest": "cargo/vendor/toml_writer-1.0.6+spec-1.1.0",
+        "contents": "{\"package\": \"7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_parser-1.0.10+spec-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml_writer/toml_writer-1.0.7+spec-1.1.0.crate",
+        "sha256": "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d",
+        "dest": "cargo/vendor/toml_writer-1.0.7+spec-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_writer-1.0.7+spec-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1107,14 +1120,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/winnow/winnow-0.7.14.crate",
-        "sha256": "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829",
-        "dest": "cargo/vendor/winnow-0.7.14"
+        "url": "https://static.crates.io/crates/winnow/winnow-0.7.15.crate",
+        "sha256": "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945",
+        "dest": "cargo/vendor/winnow-0.7.15"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829\", \"files\": {}}",
-        "dest": "cargo/vendor/winnow-0.7.14",
+        "contents": "{\"package\": \"df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945\", \"files\": {}}",
+        "dest": "cargo/vendor/winnow-0.7.15",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winnow/winnow-1.0.0.crate",
+        "sha256": "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8",
+        "dest": "cargo/vendor/winnow-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8\", \"files\": {}}",
+        "dest": "cargo/vendor/winnow-1.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/data/bootmate.gresource.xml
+++ b/data/bootmate.gresource.xml
@@ -2,5 +2,6 @@
 <gresources>
   <gresource prefix="/me/rueegger/bootmate">
     <file compressed="true" preprocess="xml-stripblanks">ui/window.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/shortcuts.ui</file>
   </gresource>
 </gresources>

--- a/data/me.rueegger.bootmate.metainfo.xml.in
+++ b/data/me.rueegger.bootmate.metainfo.xml.in
@@ -34,10 +34,16 @@
   <releases>
     <release version="50.0" date="2026-03-21">
       <description>
-        <p>Flatpak bugfixes</p>
+        <p>Major update aligning with GNOME 50</p>
         <ul>
-          <li>Fix user autostart entries not showing in Flatpak sandbox</li>
-          <li>Fix translations not loading in Flatpak</li>
+          <li>Updated to GNOME 50 runtime and SDK</li>
+          <li>Updated GTK4 to 4.22.1 and libadwaita to 1.9.0</li>
+          <li>Improved app icon resolution: icons for Flatpak apps (e.g. from X-Flatpak entries) now display correctly</li>
+          <li>Icons specified as absolute paths in .desktop files are now handled correctly</li>
+          <li>Host icon paths are now included in Flatpak sandbox for correct icon display</li>
+          <li>Added keyboard shortcut Ctrl+N to add a new autostart entry</li>
+          <li>Added keyboard shortcut Ctrl+R to refresh the list</li>
+          <li>Added keyboard shortcuts overview dialog (Ctrl+?)</li>
         </ul>
       </description>
     </release>

--- a/data/me.rueegger.bootmate.metainfo.xml.in
+++ b/data/me.rueegger.bootmate.metainfo.xml.in
@@ -32,7 +32,7 @@
   </branding>
   <content_rating type="oars-1.1" />
   <releases>
-    <release version="1.3.1" date="2026-02-21">
+    <release version="50.0" date="2026-03-21">
       <description>
         <p>Flatpak bugfixes</p>
         <ul>

--- a/data/ui/shortcuts.ui
+++ b/data/ui/shortcuts.ui
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="libadwaita" version="1.8"/>
+
+  <object class="AdwShortcutsDialog" id="shortcuts_dialog">
+    <child>
+      <object class="AdwShortcutsSection">
+        <property name="title" translatable="yes">General</property>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="title" translatable="yes">Keyboard Shortcuts</property>
+            <property name="accelerator">&lt;Primary&gt;question</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="title" translatable="yes">Quit</property>
+            <property name="accelerator">&lt;Primary&gt;q</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="AdwShortcutsSection">
+        <property name="title" translatable="yes">Autostart</property>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="title" translatable="yes">Add New Entry</property>
+            <property name="accelerator">&lt;Primary&gt;n</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="title" translatable="yes">Refresh</property>
+            <property name="accelerator">&lt;Primary&gt;r</property>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/data/ui/window.ui
+++ b/data/ui/window.ui
@@ -11,7 +11,7 @@
             <child type="start">
               <object class="GtkButton">
                 <property name="icon-name">list-add-symbolic</property>
-                <property name="tooltip-text" translatable="yes">Add Autostart Entry</property>
+                <property name="tooltip-text" translatable="yes">Add Autostart Entry (Ctrl+N)</property>
                 <property name="action-name">win.add-entry</property>
                 <style>
                   <class name="flat"/>
@@ -169,6 +169,10 @@
       </item>
     </section>
     <section>
+      <item>
+        <attribute name="label" translatable="yes">_Keyboard Shortcuts</attribute>
+        <attribute name="action">win.show-shortcuts</attribute>
+      </item>
       <item>
         <attribute name="label" translatable="yes">_About Boot Mate</attribute>
         <attribute name="action">app.about</attribute>

--- a/me.rueegger.bootmate.yml
+++ b/me.rueegger.bootmate.yml
@@ -1,6 +1,6 @@
 app-id: me.rueegger.bootmate
 runtime: org.gnome.Platform
-runtime-version: '49'
+runtime-version: '50'
 sdk: org.gnome.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable

--- a/me.rueegger.bootmate.yml
+++ b/me.rueegger.bootmate.yml
@@ -18,6 +18,9 @@ finish-args:
   - --filesystem=host-etc:ro
   # Read-only access to host /usr (for applications, icons, gnome autostart, mounted at /run/host/usr)
   - --filesystem=host-os:ro
+  # Read-only access to Flatpak exports for app icons
+  - --filesystem=/var/lib/flatpak/exports/share/icons:ro
+  - --filesystem=xdg-data/flatpak/exports/share/icons:ro
 
 build-options:
   append-path: /usr/lib/sdk/rust-stable/bin

--- a/meson.build
+++ b/meson.build
@@ -13,8 +13,8 @@ base_id = 'me.rueegger.bootmate'
 
 dependency('glib-2.0', version: '>= 2.66')
 dependency('gio-2.0', version: '>= 2.66')
-dependency('gtk4', version: '>= 4.10')
-dependency('libadwaita-1', version: '>= 1.5')
+dependency('gtk4', version: '>= 4.22.1')
+dependency('libadwaita-1', version: '>= 1.9.0')
 
 cargo = find_program('cargo', required: true)
 glib_compile_resources = find_program('glib-compile-resources', required: true)

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'bootmate',
   'rust',
-  version: '1.3.1',
+  version: '50.0',
   license: 'GPL-2.0-only',
   meson_version: '>= 0.59.0',
 )

--- a/po/de.po
+++ b/po/de.po
@@ -5,7 +5,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: bootmate 1.3.1\n"
+"Project-Id-Version: bootmate 50.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-01-28 12:00+0100\n"
 "PO-Revision-Date: 2025-01-28 12:00+0100\n"

--- a/po/de.po
+++ b/po/de.po
@@ -47,13 +47,45 @@ msgstr "Keine Autostart-Einträge"
 msgid "No applications are configured to start automatically"
 msgstr "Keine Anwendungen sind für den automatischen Start konfiguriert"
 
+#: data/ui/window.ui
+msgid "Add Autostart Entry (Ctrl+N)"
+msgstr "Autostart-Eintrag hinzufügen (Strg+N)"
+
 #: data/ui/window.ui:67
 msgid "_Refresh"
 msgstr "_Aktualisieren"
 
+#: data/ui/window.ui
+msgid "_Keyboard Shortcuts"
+msgstr "_Tastenkürzel"
+
 #: data/ui/window.ui:73
 msgid "_About Boot Mate"
 msgstr "_Über Boot Mate"
+
+#: data/ui/shortcuts.ui
+msgid "General"
+msgstr "Allgemein"
+
+#: data/ui/shortcuts.ui
+msgid "Keyboard Shortcuts"
+msgstr "Tastenkürzel"
+
+#: data/ui/shortcuts.ui
+msgid "Quit"
+msgstr "Beenden"
+
+#: data/ui/shortcuts.ui
+msgid "Autostart"
+msgstr "Autostart"
+
+#: data/ui/shortcuts.ui
+msgid "Add New Entry"
+msgstr "Neuen Eintrag hinzufügen"
+
+#: data/ui/shortcuts.ui
+msgid "Refresh"
+msgstr "Aktualisieren"
 
 #: src/entry_row.rs
 msgid "Edit"

--- a/po/en.po
+++ b/po/en.po
@@ -5,7 +5,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: bootmate 1.3.1\n"
+"Project-Id-Version: bootmate 50.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-01-28 12:00+0100\n"
 "PO-Revision-Date: 2025-01-28 12:00+0100\n"

--- a/po/en.po
+++ b/po/en.po
@@ -47,13 +47,45 @@ msgstr "No Autostart Entries"
 msgid "No applications are configured to start automatically"
 msgstr "No applications are configured to start automatically"
 
+#: data/ui/window.ui
+msgid "Add Autostart Entry (Ctrl+N)"
+msgstr "Add Autostart Entry (Ctrl+N)"
+
 #: data/ui/window.ui:67
 msgid "_Refresh"
 msgstr "_Refresh"
 
+#: data/ui/window.ui
+msgid "_Keyboard Shortcuts"
+msgstr "_Keyboard Shortcuts"
+
 #: data/ui/window.ui:73
 msgid "_About Boot Mate"
 msgstr "_About Boot Mate"
+
+#: data/ui/shortcuts.ui
+msgid "General"
+msgstr "General"
+
+#: data/ui/shortcuts.ui
+msgid "Keyboard Shortcuts"
+msgstr "Keyboard Shortcuts"
+
+#: data/ui/shortcuts.ui
+msgid "Quit"
+msgstr "Quit"
+
+#: data/ui/shortcuts.ui
+msgid "Autostart"
+msgstr "Autostart"
+
+#: data/ui/shortcuts.ui
+msgid "Add New Entry"
+msgstr "Add New Entry"
+
+#: data/ui/shortcuts.ui
+msgid "Refresh"
+msgstr "Refresh"
 
 #: src/entry_row.rs
 msgid "Edit"

--- a/src/application.rs
+++ b/src/application.rs
@@ -46,6 +46,14 @@ mod imp {
                     let icon_theme = gtk::IconTheme::for_display(&display);
                     icon_theme.add_search_path("/run/host/usr/share/icons");
                     icon_theme.add_search_path("/run/host/usr/share/pixmaps");
+                    // System Flatpak app icons
+                    icon_theme.add_search_path("/var/lib/flatpak/exports/share/icons");
+                    // User Flatpak app icons
+                    if let Ok(home) = std::env::var("HOME") {
+                        icon_theme.add_search_path(format!(
+                            "{}/.local/share/flatpak/exports/share/icons", home
+                        ));
+                    }
                 }
             }
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -35,6 +35,17 @@ mod imp {
     impl ApplicationImpl for BootMateApplication {
         fn activate(&self) {
             let application = self.obj();
+
+            // In Flatpak, GTK's icon theme doesn't include host icon paths.
+            // Add them so that named icons from host apps resolve correctly.
+            if std::env::var("FLATPAK_ID").is_ok() {
+                if let Some(display) = gtk::gdk::Display::default() {
+                    let icon_theme = gtk::IconTheme::for_display(&display);
+                    icon_theme.add_search_path("/run/host/usr/share/icons");
+                    icon_theme.add_search_path("/run/host/usr/share/pixmaps");
+                }
+            }
+
             let window = if let Some(window) = application.active_window() {
                 window
             } else {

--- a/src/application.rs
+++ b/src/application.rs
@@ -29,6 +29,9 @@ mod imp {
             obj.setup_gactions();
             obj.set_accels_for_action("app.quit", &["<primary>q"]);
             obj.set_accels_for_action("window.close", &["<primary>w"]);
+            obj.set_accels_for_action("win.add-entry", &["<primary>n"]);
+            obj.set_accels_for_action("win.refresh", &["<primary>r"]);
+            obj.set_accels_for_action("win.show-shortcuts", &["<primary>question"]);
         }
     }
 

--- a/src/autostart.rs
+++ b/src/autostart.rs
@@ -43,6 +43,7 @@ impl AutostartEntry {
         let mut comment = None;
         let mut enabled = true;
         let mut in_desktop_entry = false;
+        let mut flatpak_id = None;
 
         for line in content.lines() {
             let line = line.trim();
@@ -65,6 +66,12 @@ impl AutostartEntry {
                     "Exec" => exec = Some(value.to_string()),
                     "Icon" => icon = Some(value.to_string()),
                     "Comment" => comment = Some(value.to_string()),
+                    "X-Flatpak" => flatpak_id = Some(value.to_string()),
+                    "X-XDP-Autostart" => {
+                        if flatpak_id.is_none() {
+                            flatpak_id = Some(value.to_string());
+                        }
+                    }
                     "X-GNOME-Autostart-enabled" => {
                         enabled = value.to_lowercase() != "false";
                     }
@@ -80,6 +87,16 @@ impl AutostartEntry {
 
         let name = name.ok_or("Missing Name field")?;
         let exec = exec.ok_or("Missing Exec field")?;
+
+        // If no Icon= was set, derive from X-Flatpak/X-XDP-Autostart ID,
+        // then fall back to the filename stem (works for most Flatpak-generated entries)
+        if icon.is_none() {
+            if let Some(id) = flatpak_id {
+                icon = Some(id);
+            } else if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                icon = Some(stem.to_string());
+            }
+        }
 
         let is_user_entry = path.to_string_lossy().contains(".config/autostart");
 

--- a/src/entry_row.rs
+++ b/src/entry_row.rs
@@ -63,11 +63,26 @@ impl EntryRow {
         prefix_box.append(&enable_switch);
 
         // Set icon with larger size
-        let icon = if let Some(icon_name) = &entry.icon {
-            gtk::Image::builder()
-                .icon_name(icon_name)
-                .pixel_size(32)
-                .build()
+        let icon = if let Some(icon_str) = &entry.icon {
+            if icon_str.starts_with('/') {
+                // Absolute path: in Flatpak, also try the host-prefixed path
+                let path = if std::path::Path::new(icon_str.as_str()).exists() {
+                    icon_str.clone()
+                } else if std::env::var("FLATPAK_ID").is_ok() {
+                    format!("/run/host{}", icon_str)
+                } else {
+                    icon_str.clone()
+                };
+                gtk::Image::builder()
+                    .file(&path)
+                    .pixel_size(32)
+                    .build()
+            } else {
+                gtk::Image::builder()
+                    .icon_name(icon_str)
+                    .pixel_size(32)
+                    .build()
+            }
         } else {
             gtk::Image::builder()
                 .icon_name("application-x-executable")

--- a/src/window.rs
+++ b/src/window.rs
@@ -93,7 +93,13 @@ impl BootMateWindow {
             })
             .build();
 
-        self.add_action_entries([action_refresh, action_add_entry]);
+        let action_show_shortcuts = gio::ActionEntry::builder("show-shortcuts")
+            .activate(|window: &Self, _, _| {
+                window.show_shortcuts();
+            })
+            .build();
+
+        self.add_action_entries([action_refresh, action_add_entry, action_show_shortcuts]);
     }
 
     pub fn load_autostart_entries(&self) {
@@ -356,6 +362,14 @@ impl BootMateWindow {
             ),
         );
 
+        dialog.present(Some(self));
+    }
+
+    fn show_shortcuts(&self) {
+        let builder = gtk::Builder::from_resource("/me/rueegger/bootmate/ui/shortcuts.ui");
+        let dialog = builder
+            .object::<adw::ShortcutsDialog>("shortcuts_dialog")
+            .unwrap();
         dialog.present(Some(self));
     }
 

--- a/update-version.sh
+++ b/update-version.sh
@@ -5,15 +5,16 @@ set -e
 
 if [ -z "$1" ]; then
     echo "Usage: ./update-version.sh <new-version>"
+    echo "Example: ./update-version.sh 50.0"
     echo "Example: ./update-version.sh 1.2.0"
     exit 1
 fi
 
 NEW_VERSION="$1"
 
-# Validate version format (X.Y.Z)
-if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "Error: Version must be in format X.Y.Z (e.g., 1.2.0)"
+# Validate version format (X.Y or X.Y.Z)
+if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+    echo "Error: Version must be in format X.Y or X.Y.Z (e.g., 50.0 or 1.2.0)"
     exit 1
 fi
 
@@ -21,33 +22,28 @@ echo "Updating version to $NEW_VERSION..."
 
 # Update meson.build
 echo "  - meson.build"
-sed -i "s/version: '[0-9]\+\.[0-9]\+\.[0-9]\+'/version: '$NEW_VERSION'/" meson.build
+sed -i "s/version: '[0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?'/version: '$NEW_VERSION'/" meson.build
 
-# Update Cargo.toml
+# Update Cargo.toml (requires 3-component semver, append .0 for X.Y versions)
 echo "  - Cargo.toml"
-sed -i "s/^version = \"[0-9]\+\.[0-9]\+\.[0-9]\+\"/version = \"$NEW_VERSION\"/" Cargo.toml
+if [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+    CARGO_VERSION="${NEW_VERSION}.0"
+else
+    CARGO_VERSION="$NEW_VERSION"
+fi
+sed -i "s/^version = \"[0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?\"/version = \"$CARGO_VERSION\"/" Cargo.toml
 
 # Update po files
 echo "  - po/en.po"
-sed -i "s/Project-Id-Version: bootmate [0-9]\+\.[0-9]\+\.[0-9]\+/Project-Id-Version: bootmate $NEW_VERSION/" po/en.po
+sed -i "s/Project-Id-Version: bootmate [0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?/Project-Id-Version: bootmate $NEW_VERSION/" po/en.po
 
 echo "  - po/de.po"
-sed -i "s/Project-Id-Version: bootmate [0-9]\+\.[0-9]\+\.[0-9]\+/Project-Id-Version: bootmate $NEW_VERSION/" po/de.po
+sed -i "s/Project-Id-Version: bootmate [0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?/Project-Id-Version: bootmate $NEW_VERSION/" po/de.po
 
 # Update metainfo.xml.in - only update the first (newest) release version
 echo "  - data/me.rueegger.bootmate.metainfo.xml.in"
-# Get current date in YYYY-MM-DD format
 CURRENT_DATE=$(date +%Y-%m-%d)
-# Update only the first occurrence of release version
-sed -i "0,/<release version=\"[0-9]\+\.[0-9]\+\.[0-9]\+\"/s/<release version=\"[0-9]\+\.[0-9]\+\.[0-9]\+\" date=\"[^\"]*\">/<release version=\"$NEW_VERSION\" date=\"$CURRENT_DATE\">/" data/me.rueegger.bootmate.metainfo.xml.in
-
-# Update RELEASE.md
-echo "  - RELEASE.md"
-sed -i "s/\*\*Aktuelle Version:\*\* [0-9]\+\.[0-9]\+\.[0-9]\+/**Aktuelle Version:** $NEW_VERSION/" RELEASE.md
-
-# Update bootmate.spec
-echo "  - bootmate.spec"
-sed -i "s/^Version:        [0-9]\+\.[0-9]\+\.[0-9]\+/Version:        $NEW_VERSION/" bootmate.spec
+sed -i "0,/<release version=\"[0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?\"/s/<release version=\"[0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?\" date=\"[^\"]*\">/<release version=\"$NEW_VERSION\" date=\"$CURRENT_DATE\">/" data/me.rueegger.bootmate.metainfo.xml.in
 
 echo ""
 echo "Version updated to $NEW_VERSION successfully!"
@@ -58,8 +54,6 @@ echo "  - Cargo.toml"
 echo "  - po/en.po"
 echo "  - po/de.po"
 echo "  - data/me.rueegger.bootmate.metainfo.xml.in (version and date)"
-echo "  - RELEASE.md"
-echo "  - bootmate.spec"
 echo ""
 echo "Next steps:"
 echo "  1. Review changes: git diff"


### PR DESCRIPTION
This pull request prepares for a major new release of Boot Mate, updating the project for compatibility with GNOME 50 and modernizing its dependencies and release process. The most significant changes include bumping the version to 50.0.0, updating Rust and system dependencies, and revising the release documentation and workflow to match the new versioning scheme.

**Version and release process updates:**

* Bumped the project version to `50.0.0` in `Cargo.toml` and switched the edition to `2024`, aligning with the GNOME 50 release cycle and adopting a new MAJOR.MINOR versioning scheme. The release process in `RELEASE.md` was rewritten to reflect this, with a new workflow for updating versions and publishing releases. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R20) [[2]](diffhunk://#diff-2b1b69303b927a484e02c7fad9fc87d0d3ff0dc22ae1da0ecd0dc935d922a23cL5-R116)

**Dependency updates:**

* Updated Rust dependencies in `Cargo.toml` to newer versions of `gtk`, `libadwaita`, `glib`, and `gio`, and revised their feature flags to require the latest API versions.
* Updated system dependency requirements in `README.md` and `CLAUDE.md` to require GTK 4.22.1 and libadwaita 1.9.0 or later. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L69-R70) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L15-R15)
* Updated vendored Rust dependencies in `cargo-sources.json` to match the new versions, including `cairo-rs`, `cc`, `cfg-expr`, `gdk-pixbuf`, `gdk4`, and their corresponding `-sys` crates. [[1]](diffhunk://#diff-03ac8d1ce79a72f96976cdd9a713266914aaaa38b8dbac0967c1082c09374468L57-R103) [[2]](diffhunk://#diff-03ac8d1ce79a72f96976cdd9a713266914aaaa38b8dbac0967c1082c09374468L239-R285)

**Metadata and documentation improvements:**

* Updated project metadata, such as the copyright and 
maintainer email in `Cargo.toml`, and clarified links and versioning notes in `RELEASE.md`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R20) [[2]](diffhunk://#diff-2b1b69303b927a484e02c7fad9fc87d0d3ff0dc22ae1da0ecd0dc935d922a23cL5-R116)

These changes ensure Boot Mate is ready for the next GNOME cycle, with up-to-date dependencies and a streamlined, modern release process.